### PR TITLE
ヘッダーのレスポンシブ対応

### DIFF
--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -1,7 +1,7 @@
 <%= render "shared/header" %>
 
 <main class="container">
-  <div class="row gy-8">
+  <div class="row py-3">
     <div class="col-sm-8">
       <div class="p-4 p-md-5 mb-4 bg-info">
         <p class="display-6 fw-italic">ずっと疑問だったF1英語は<br>ありませんか？</p>
@@ -24,11 +24,11 @@
       </div>
     </div>
     <div class="col-sm-4">
-      <div class="p-4 mb-3 bg-light rounded">
+      <div class="p-4 mb-4 bg-white rounded">
         <h4 class="font-italic">このサービスについて</h4>
         <p class="mb-0">ここで作成された和訳は管理者の推測に基づいたものであり、実際のドライバーの意向を表したものではありません。</p>
       </div>
-      <div class="p-4 mb-3 bg-light rounded">
+      <div class="p-4 mb-4 bg-white rounded">
         <h4 class="font-italic">注意点</h4>
         <p class="mb-0">ここで作成された和訳は管理者の推測に基づいたものであり、実際のドライバーの意向を表したものではありません。</p>
       </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,10 +1,10 @@
-<header class="px-5 py-3 bg-white">
+<header class="py-3 bg-white">
   <div class="container">
-    <div class="row flex-nowrap justify-content-between align-items-center">
-      <div class="col-4 pt-1">
+    <div class="row">
+      <div class="col-6 align-self-center">
         <%= link_to image_tag("formula-icon.png", class:"img-fluid"), "/" %>
       </div>
-      <div class="col-4 text-start">
+      <div class="col-6 align-self-center">
         <% if user_signed_in? %>
           <%= "こんにちは、#{current_user.nickname}さん" %><br>
           <%= "ログアウトは" %><%= link_to "こちら", destroy_user_session_path, method: :delete, class:"text-decoration-none" %>
@@ -13,7 +13,10 @@
           <dt><%= link_to "ログイン", new_user_session_path, class:"text-decoration-none" %></dt>
         <% end %>
       </div>
-      <div class="col-4 d-flex justify-content-end">
+    </div>
+    <hr>
+    <div class="row justify-content-end">
+      <div class="col-3 d-none d-md-block">
         <%= link_to "質問する", new_question_path, class:"btn btn-primary btn-lg" %>
       </div>
     </div>


### PR DESCRIPTION
# What
スマホサイズの時の不自然な表示の解消

# Why
スマホ表示になったときに、ロゴが小さくなる、新規要録の文言に不自然な折り返しが発生する、質問ボタンが２行になってしまう現象は見た目が良くないため